### PR TITLE
Explicit waits updated

### DIFF
--- a/WebDriverTimeoutsTutorial/DynamicControlsTests.cs
+++ b/WebDriverTimeoutsTutorial/DynamicControlsTests.cs
@@ -1,0 +1,54 @@
+﻿using AutomationResources;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using ExpectedConditions = SeleniumExtras.WaitHelpers.ExpectedConditions;
+
+namespace WebDriverTimeoutsTutorial
+{
+    class DynamicControlsTests
+    {
+        private IWebDriver _driver;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _driver = new WebDriverFactory().Create(BrowserType.Chrome);
+        }
+        [TestCleanup]
+        public void Teardown()
+        {
+            _driver.Close();
+            _driver.Quit();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NoSuchElementException))]
+        public void DynamicControlsTest()
+        {
+            _driver.Navigate().GoToUrl(URL.DynamicControlsURL);
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
+        }
+
+        [TestMethod]
+        public void DynamicControlsTest_FixedImplicitly()
+        {
+            _driver.Navigate().GoToUrl(URL.DynamicControlsURL);
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(5);
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
+        }
+
+        [TestMethod]
+        public void DynamicControlsTest_FixedExplicitly()
+        {
+            _driver.Navigate().GoToUrl(URL.DynamicControlsURL);
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
+            wait.Until(ExpectedConditions.InvisibilityOfElementLocated(By.XPath("//input[@type='checkbox']")));
+            Assert.IsTrue(wait.Until(ExpectedConditions.ElementIsVisible(By.Id("message"))).Displayed);
+        }
+    }
+}

--- a/WebDriverTimeoutsTutorial/ExplicitWaits.cs
+++ b/WebDriverTimeoutsTutorial/ExplicitWaits.cs
@@ -57,7 +57,7 @@ namespace WebdriverTimeoutsTutorial
         [TestMethod]
         public void Test3_ExplicitWait_HiddenElement()
         {
-            _driver.Navigate().GoToUrl(URL.HiddenElementUrl);           
+            _driver.Navigate().GoToUrl(URL.HiddenElementUrl);
             _driver.FindElement(By.XPath("//button[contains(text(),'Start')]")).Click();
             var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(5));
             wait.Until(ExpectedConditions.ElementToBeClickable(ElementToWaitFor)).Click();

--- a/WebDriverTimeoutsTutorial/ExplicitWaits.cs
+++ b/WebDriverTimeoutsTutorial/ExplicitWaits.cs
@@ -47,11 +47,11 @@ namespace WebdriverTimeoutsTutorial
         [TestMethod]
         public void Test1_FixedExplicitly()
         {
-            _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
-            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            _driver.Navigate().GoToUrl(URL.SlowAnimationUrl); 
+            FillOutCreditCardInfo();
             var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
-            wait.Until(ExpectedConditions.InvisibilityOfElementLocated(By.XPath("//input[@type='checkbox']")));
-            Assert.IsTrue(wait.Until(ExpectedConditions.ElementIsVisible(By.Id("message"))).Displayed);
+            wait.Until(ExpectedConditions.ElementToBeClickable(By.Id("go"))).Click();
+            Assert.IsTrue(wait.Until(ExpectedConditions.ElementIsVisible(By.Id("success"))).Displayed);
         }
 
         [TestMethod]
@@ -91,6 +91,14 @@ namespace WebdriverTimeoutsTutorial
 
             var finalElement = wait.Until(ExpectedConditions.ElementIsVisible(By.XPath("//*[@title='girl with laptop 2']")));
             Assert.IsTrue(finalElement.Displayed);
+        }
+
+        private void FillOutCreditCardInfo()
+        {
+            _driver.FindElement(By.Id("name")).SendKeys("test name");
+            _driver.FindElement(By.Id("cc")).SendKeys("1234123412341234");
+            _driver.FindElement(By.Id("month")).SendKeys("01");
+            _driver.FindElement(By.Id("year")).SendKeys("2020");
         }
     }
 }

--- a/WebDriverTimeoutsTutorial/ExplicitWaits.cs
+++ b/WebDriverTimeoutsTutorial/ExplicitWaits.cs
@@ -48,10 +48,10 @@ namespace WebdriverTimeoutsTutorial
         public void Test1_FixedExplicitly()
         {
             _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
-            FillOutCreditCardInfo();
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
             var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
-            wait.Until(ExpectedConditions.ElementToBeClickable(By.Id("go"))).Click();
-            Assert.IsTrue(wait.Until(ExpectedConditions.ElementIsVisible(By.Id("success"))).Displayed);
+            wait.Until(ExpectedConditions.InvisibilityOfElementLocated(By.XPath("//input[@type='checkbox']")));
+            Assert.IsTrue(wait.Until(ExpectedConditions.ElementIsVisible(By.Id("message"))).Displayed);
         }
 
         [TestMethod]
@@ -91,14 +91,6 @@ namespace WebdriverTimeoutsTutorial
 
             var finalElement = wait.Until(ExpectedConditions.ElementIsVisible(By.XPath("//*[@title='girl with laptop 2']")));
             Assert.IsTrue(finalElement.Displayed);
-        }
-
-        private void FillOutCreditCardInfo()
-        {
-            _driver.FindElement(By.Id("name")).SendKeys("test name");
-            _driver.FindElement(By.Id("cc")).SendKeys("1234123412341234");
-            _driver.FindElement(By.Id("month")).SendKeys("01");
-            _driver.FindElement(By.Id("year")).SendKeys("2020");
         }
     }
 }

--- a/WebDriverTimeoutsTutorial/ImplicitWaits.cs
+++ b/WebDriverTimeoutsTutorial/ImplicitWaits.cs
@@ -26,32 +26,21 @@ namespace WebdriverTimeoutsTutorial
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ElementNotVisibleException))]
+        [ExpectedException(typeof(NoSuchElementException))]
         public void Test1()
         {
             _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
-            FillOutCreditCardInfo();
-            _driver.FindElement(By.Id("go")).Click();
-            Assert.IsTrue(_driver.FindElement(By.Id("success")).Displayed);
-        }
-
-        private void FillOutCreditCardInfo()
-        {
-            _driver.FindElement(By.Id("name")).SendKeys("test name");
-            _driver.FindElement(By.Id("cc")).SendKeys("1234123412341234");
-            _driver.FindElement(By.Id("month")).SendKeys("01");
-            _driver.FindElement(By.Id("year")).SendKeys("2020");
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ElementNotVisibleException))]
         public void Test1_FixedImplicitly()
         {
             _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
             _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(5);
-            FillOutCreditCardInfo();
-            _driver.FindElement(By.Id("go")).Click();
-            Assert.IsTrue(_driver.FindElement(By.Id("success")).Displayed);
+            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
         }
         [TestMethod]
         [ExpectedException(typeof(NoSuchElementException))]

--- a/WebDriverTimeoutsTutorial/ImplicitWaits.cs
+++ b/WebDriverTimeoutsTutorial/ImplicitWaits.cs
@@ -15,7 +15,7 @@ namespace WebdriverTimeoutsTutorial
         [TestInitialize]
         public void Setup()
         {
-           _driver = new WebDriverFactory().Create(BrowserType.Chrome);
+            _driver = new WebDriverFactory().Create(BrowserType.Chrome);
         }
 
         [TestCleanup]
@@ -26,21 +26,32 @@ namespace WebdriverTimeoutsTutorial
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NoSuchElementException))]
+        [ExpectedException(typeof(ElementNotVisibleException))]
         public void Test1()
         {
             _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
-            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
-            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
+            FillOutCreditCardInfo();
+            _driver.FindElement(By.Id("go")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("success")).Displayed);
+        }
+
+        private void FillOutCreditCardInfo()
+        {
+            _driver.FindElement(By.Id("name")).SendKeys("test name");
+            _driver.FindElement(By.Id("cc")).SendKeys("1234123412341234");
+            _driver.FindElement(By.Id("month")).SendKeys("01");
+            _driver.FindElement(By.Id("year")).SendKeys("2020");
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ElementNotVisibleException))]
         public void Test1_FixedImplicitly()
         {
             _driver.Navigate().GoToUrl(URL.SlowAnimationUrl);
             _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(5);
-            _driver.FindElement(By.XPath("//button[@onclick='swapCheckbox()']")).Click();
-            Assert.IsTrue(_driver.FindElement(By.Id("message")).Displayed);
+            FillOutCreditCardInfo();
+            _driver.FindElement(By.Id("go")).Click();
+            Assert.IsTrue(_driver.FindElement(By.Id("success")).Displayed);
         }
         [TestMethod]
         [ExpectedException(typeof(NoSuchElementException))]

--- a/WebDriverTimeoutsTutorial/URL.cs
+++ b/WebDriverTimeoutsTutorial/URL.cs
@@ -11,6 +11,6 @@ namespace WebDriverTimeoutsTutorial
         public static string HiddenElementUrl => "https://the-internet.herokuapp.com/dynamic_loading/1";
 
         public static string ElementRenderedAfterUrl => "https://the-internet.herokuapp.com/dynamic_loading/2";
-        public static string SlowAnimationUrl => "http://awful-valentine.com/purchase-forms/slow-animation/";
+        public static string SlowAnimationUrl => "https://the-internet.herokuapp.com/dynamic_controls";
     }
 }

--- a/WebDriverTimeoutsTutorial/URL.cs
+++ b/WebDriverTimeoutsTutorial/URL.cs
@@ -11,6 +11,7 @@ namespace WebDriverTimeoutsTutorial
         public static string HiddenElementUrl => "https://the-internet.herokuapp.com/dynamic_loading/1";
 
         public static string ElementRenderedAfterUrl => "https://the-internet.herokuapp.com/dynamic_loading/2";
-        public static string SlowAnimationUrl => "https://the-internet.herokuapp.com/dynamic_controls";
+        public static string SlowAnimationUrl => "http://awful-valentine.com/purchase-forms/slow-animation/";
+        public static string DynamicControlsURL => "https://the-internet.herokuapp.com/dynamic_controls";
     }
 }

--- a/WebDriverTimeoutsTutorial/WebDriverTimeoutsTutorial.csproj
+++ b/WebDriverTimeoutsTutorial/WebDriverTimeoutsTutorial.csproj
@@ -59,6 +59,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DynamicControlsTests.cs" />
     <Compile Include="ExplicitWaits.cs" />
     <Compile Include="ImplicitWaits.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/WebDriverTimeoutsTutorial/WebDriverTimeoutsTutorial.csproj
+++ b/WebDriverTimeoutsTutorial/WebDriverTimeoutsTutorial.csproj
@@ -81,8 +81,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.85.0.4183.8700\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.85.0.4183.8700\build\Selenium.WebDriver.ChromeDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
-  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.85.0.4183.8700\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.85.0.4183.8700\build\Selenium.WebDriver.ChromeDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.91.0.4472.1900\build\Selenium.WebDriver.ChromeDriver.targets')" />
 </Project>

--- a/WebDriverTimeoutsTutorial/packages.config
+++ b/WebDriverTimeoutsTutorial/packages.config
@@ -5,5 +5,5 @@
   <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net472" />
   <package id="Selenium.Support" version="3.141.0" targetFramework="net461" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net461" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="85.0.4183.8700" targetFramework="net472" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="91.0.4472.1900" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
@nadvolod I updated the 3 tests that were using AwfulValentine with this URL: https://the-internet.herokuapp.com/dynamic_controls
The scenario is:
- navigate to the page
- click the Remove button
- wait for the checkbox to be disabled
- assert that the message is displayed